### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "npm install"

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # DiscoRape
-
+[![Run on Repl.it](https://repl.it/badge/github/GoByeBye/DiscoRape)](https://repl.it/github/GoByeBye/DiscoRape)
 DiscoRape is a selfbot for Discord written in python3.8
 The original repository I forked this from can be found here [made by EC-discord](https://github.com/EC-discord/self-bot)
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).